### PR TITLE
refactor: align auth with http-only cookies

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -10,7 +10,6 @@ import Play from "@/components/icons/play.svg"
 import { MdOutlineCalendarMonth } from "react-icons/md"
 import { cn } from "@/lib/utils"
 import { AuthService } from "@/services/auth/auth.service"
-import { removeAuthToken } from "@/lib/api"
 
 const mainNavigation = [
   { name: "Home", href: "/dashboard", icon: Home },
@@ -35,13 +34,10 @@ export function Sidebar() {
     try {
       console.log('Fazendo logout...')
       await authService.logout()
-      removeAuthToken()
       console.log('Logout realizado com sucesso')
       router.push('/login')
     } catch (error) {
       console.error('Erro no logout:', error)
-      // Even if logout fails, clear tokens and redirect
-      removeAuthToken()
       router.push('/login')
     }
   }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,88 +2,18 @@ import axios from 'axios';
 
 export const api = axios.create({
     baseURL: process.env.BACKEND_URL || 'http://localhost:5000',
-    withCredentials: true, // This sends HttpOnly cookies automatically
+    withCredentials: true, // permite envio automático de cookies HttpOnly
     headers: {
         'Content-Type': 'application/json',
     },
 });
 
-// Cookie helper function
-const getCookie = (name: string): string | null => {
-    if (typeof window === 'undefined') return null;
-    
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) {
-        return parts.pop()?.split(';').shift() || null;
-    }
-    return null;
-};
-
-// Token management functions
-export const getAuthToken = (): string | null => {
-    if (typeof window !== 'undefined') {
-        // First try to get from cookie
-        const cookieToken = getCookie('access_token');
-        if (cookieToken) {
-            return cookieToken;
-        }
-        
-        // Fallback to localStorage/sessionStorage
-        return localStorage.getItem('authToken') || sessionStorage.getItem('authToken');
-    }
-    return null;
-};
-
-export const setAuthToken = (token: string, remember: boolean = false): void => {
-    if (typeof window !== 'undefined') {
-        if (remember || token === ' ') {
-            localStorage.setItem('authToken', token);
-            sessionStorage.removeItem('authToken');
-        } else {
-            sessionStorage.setItem('authToken', token);
-            localStorage.removeItem('authToken');
-        }
-    }
-};
-
-export const removeAuthToken = (): void => {
-    if (typeof window !== 'undefined') {
-        localStorage.removeItem('authToken');
-        sessionStorage.removeItem('authToken');
-    }
-};
-
-// Request interceptor to add Bearer token
-api.interceptors.request.use(
-    (config) => {
-        const token = getAuthToken();
-        console.log('Interceptor - Token encontrado:', token ? 'Sim' : 'Não');
-        console.log('Interceptor - Token valor:', token);
-        
-        if (token) {
-            config.headers.Authorization = `Bearer ${token}`;
-            console.log('Interceptor - Header Authorization definido');
-        } else {
-            console.log('Interceptor - Nenhum token encontrado');
-        }
-        return config;
-    },
-    (error) => {
-        return Promise.reject(error);
-    }
-);
-
 // Response interceptor to handle unauthorized responses
 api.interceptors.response.use(
     (response) => response,
     (error) => {
-        if (error.response?.status === 401) {
-            // Remove invalid token and redirect to login
-            removeAuthToken();
-            if (typeof window !== 'undefined') {
-                window.location.href = '/login';
-            }
+        if (error.response?.status === 401 && typeof window !== 'undefined') {
+            window.location.href = '/login';
         }
         return Promise.reject(error);
     }

--- a/services/auth/auth.repository.ts
+++ b/services/auth/auth.repository.ts
@@ -7,7 +7,7 @@ export class AuthRepository {
         return data;
     }
 
-    async login(dto: AuthBaseDTO): Promise<{ verified: boolean, token?: string }> {
+    async login(dto: AuthBaseDTO): Promise<{ verified: boolean }> {
         const {data} = await api.post('/auth/login', dto);
         return data;
     }

--- a/services/auth/auth.service.ts
+++ b/services/auth/auth.service.ts
@@ -1,6 +1,5 @@
 import {AuthRepository} from "@/services/auth/auth.repository";
 import {AuthBaseDTO, RegisterDTO} from "@/interfaces/auth";
-import {setAuthToken} from "@/lib/api";
 
 export class AuthService {
     private repository: AuthRepository;
@@ -13,15 +12,8 @@ export class AuthService {
         return this.repository.register(dto);
     }
 
-    async login(dto: AuthBaseDTO, remember: boolean = false): Promise<{ verified: boolean }> {
-        const response = await this.repository.login(dto);
-        
-        // Save JWT token if provided
-        if (response.token) {
-            setAuthToken(response.token, remember);
-        }
-        
-        return response;
+    async login(dto: AuthBaseDTO): Promise<{ verified: boolean }> {
+        return this.repository.login(dto);
     }
 
     async logout(): Promise<void> {


### PR DESCRIPTION
## Summary
- remove client-side token handling and Authorization headers
- rely on withCredentials for HttpOnly cookie auth
- simplify logout workflow

## Testing
- `npm run lint` *(fails: requires ESLint configuration)*
- `npm run build` *(fails: Failed to fetch Inter font from Google)*

------
https://chatgpt.com/codex/tasks/task_e_6898bade737883248d734659b27c5eab